### PR TITLE
플레이어 양초, 손전등 추가

### DIFF
--- a/Assets/Prefabs/Map/MAP.prefab
+++ b/Assets/Prefabs/Map/MAP.prefab
@@ -113830,6 +113830,7 @@ Transform:
   - {fileID: 3869764375480190162}
   - {fileID: 1566993430190969293}
   - {fileID: 3196491465070116668}
+  - {fileID: 8364336290727963975}
   m_Father: {fileID: 7635793256736820218}
   m_LocalEulerAnglesHint: {x: 0, y: -45.000004, z: 0}
 --- !u!205 &8111512862510134752
@@ -222288,6 +222289,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   letterObject: {fileID: 3283619572438387786}
+  tableCandle: {fileID: 7683336656349573671}
+  playerTag: Player
+  playerCandleLightName: CandleLight
 --- !u!1 &8340830671354307192
 GameObject:
   m_ObjectHideFlags: 0
@@ -247191,6 +247195,158 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 5038063561147303676, guid: 32424c84029339944a17a7d1dae3ad64, type: 3}
   m_PrefabInstance: {fileID: 6503044004910917699}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8360069314369535379
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3948529124634722961}
+    m_Modifications:
+    - target: {fileID: 1002705123656268, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_Name
+      value: FlashlightItem
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.1215766
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.8743806
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.21291037
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.1230046
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.123004556
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.69632596
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.6963261
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180
+      objectReference: {fileID: 0}
+    - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 114.964
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1002705123656268, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6230817758827904044}
+    - targetCorrespondingSourceObject: {fileID: 1002705123656268, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7365929064562995779}
+    - targetCorrespondingSourceObject: {fileID: 1175331865632600, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 445835522382078582}
+  m_SourcePrefab: {fileID: 100100000, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+--- !u!1 &8358894532338361035 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1175331865632600, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+  m_PrefabInstance: {fileID: 8360069314369535379}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &445835522382078582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8358894532338361035}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalLightData
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
+--- !u!1 &8360758208223412191 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1002705123656268, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+  m_PrefabInstance: {fileID: 8360069314369535379}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6230817758827904044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8360758208223412191}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3e3544a6a0ff2441a3a69b7db95f594, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::FlashlightPickup
+  interactKey: 101
+--- !u!65 &7365929064562995779
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8360758208223412191}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 0.5}
+  m_Center: {x: -0.36, y: -1.2212453e-15, z: -0.0000004172325}
+--- !u!4 &8364336290727963975 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+  m_PrefabInstance: {fileID: 8360069314369535379}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8395388666701508521
 PrefabInstance:

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -189,6 +189,133 @@ Transform:
   m_Children: []
   m_Father: {fileID: 465357237215718605}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1423731012111256680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1819767876777162948}
+  - component: {fileID: 1145962657751740783}
+  - component: {fileID: 2602783821337051207}
+  m_Layer: 0
+  m_Name: CandleLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1819767876777162948
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423731012111256680}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.176, y: 0.049, z: 0.196}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1357872468683691416}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!108 &1145962657751740783
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423731012111256680}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 2
+  m_Color: {r: 1, g: 0.72156864, b: 0.3764706, a: 1}
+  m_Intensity: 2
+  m_Range: 5
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!114 &2602783821337051207
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423731012111256680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalLightData
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
 --- !u!1 &1442548540900074707
 GameObject:
   m_ObjectHideFlags: 0
@@ -501,6 +628,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4298097763609160298}
+  - {fileID: 1819767876777162948}
   m_Father: {fileID: 995186213807406024}
   m_LocalEulerAnglesHint: {x: -14.118, y: -161.075, z: 148.042}
 --- !u!114 &5708103234251061222
@@ -2465,8 +2593,8 @@ GameObject:
   - component: {fileID: 7957581771741302358}
   - component: {fileID: 7422836436060642329}
   - component: {fileID: 1145863333505786670}
-  - component: {fileID: 6823668258551287832}
   - component: {fileID: 4616579930363841916}
+  - component: {fileID: 1439360795269774629}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -2835,21 +2963,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &6823668258551287832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6665924648948749789}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2c41da59de72bf8429bf57b320b168e0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::FlashlightToggle
-  lightAudioSource: {fileID: 0}
-  lightOnClip: {fileID: 0}
-  lightOffClip: {fileID: 0}
 --- !u!320 &4616579930363841916
 PlayableDirector:
   m_ObjectHideFlags: 0
@@ -2875,6 +2988,21 @@ PlayableDirector:
     - 21b43fb31f7df54468e0ea880ac435a6: {fileID: 5055551999926291654}
     - 04b9a4715aceac4429d0c6820689484d: {fileID: 0}
     - 2666255210da1b740971ef630b8d79bb: {fileID: 0}
+--- !u!114 &1439360795269774629
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6665924648948749789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68ebbe38f3fff8540a9d1797a89fb99f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerLightInventory
+  candleLight: {fileID: 1423731012111256680}
+  flashlightObject: {fileID: 4302802302201952498}
+  hasFlashlight: 0
 --- !u!1 &6761608561348423338
 GameObject:
   m_ObjectHideFlags: 0
@@ -4412,7 +4540,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1767310008238479403, guid: 6f5c89de9c90e46858810b535bbcf29b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.02710004
+      value: 0.027100513
       objectReference: {fileID: 0}
     - target: {fileID: 1767310008238479403, guid: 6f5c89de9c90e46858810b535bbcf29b, type: 3}
       propertyPath: m_LocalPosition.y
@@ -4420,7 +4548,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1767310008238479403, guid: 6f5c89de9c90e46858810b535bbcf29b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.0120583065
+      value: 0.012058429
       objectReference: {fileID: 0}
     - target: {fileID: 1767310008238479403, guid: 6f5c89de9c90e46858810b535bbcf29b, type: 3}
       propertyPath: m_LocalRotation.w
@@ -4678,6 +4806,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Flashlight
       objectReference: {fileID: 0}
+    - target: {fileID: 1002705123656268, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4777606630871252, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.054035395
@@ -4774,6 +4906,11 @@ MonoBehaviour:
   m_ShadowLayerMask: 1
   m_RenderingLayers: 1
   m_ShadowRenderingLayers: 1
+--- !u!1 &4302802302201952498 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1002705123656268, guid: d86ca2f4159e6a942abd8dfc52b38395, type: 3}
+  m_PrefabInstance: {fileID: 4302362688313309886}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8543325853763389502
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Letter.cs
+++ b/Assets/Scripts/Letter.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using UnityEngine;
 
 public class Letter : MonoBehaviour
@@ -24,7 +24,16 @@ public class Letter : MonoBehaviour
     private bool isInRange = false; // 플레이어가 범위 내에 있는지 여부
     private bool isReading = false; // 편지 UI가 열려있는지 여부
     private bool isOpenDoor = false; // 문이 열려있는지
-    
+
+    // 🔥 책상 위에 있는 Candle_01 오브젝트 (MAP/Furniture/.../Candle_01)
+    [SerializeField] private GameObject tableCandle;
+
+    // Inspector 에선 비워두고 런타임에 찾는다
+    [SerializeField] private string playerTag = "Player";
+    [SerializeField] private string playerCandleLightName = "CandleLight";
+    private GameObject playerCandleLight;
+    private bool candleActivated = false;
+
     void Update()
     {
         if (_player == null)
@@ -69,6 +78,30 @@ public class Letter : MonoBehaviour
     {
         letterImage.SetActive(false); // UI 숨김
         isReading = false;
+
+        if(!candleActivated)
+        {
+            candleActivated = true;
+
+            // 플레이어 프리펩에 존재하는 양초 불빛 오브젝트 찾기
+            TryFindPlayerCandle();
+
+            //책상 위의 촛불 제거(플레이어가 획득한 것처럼)
+            if(tableCandle != null)
+            {
+                Destroy(tableCandle);
+            }
+            //플레이어 양초 불 활성화
+            if (playerCandleLight != null)
+            {
+                Debug.Log("양초 불 활성화");
+                playerCandleLight.SetActive(true);
+            }
+            else
+            {
+                Debug.Log("양초 불 활성화 못함!");
+            }
+        }
     }
 
     private IEnumerator DelayOpenLetter()
@@ -88,5 +121,34 @@ public class Letter : MonoBehaviour
     public void SetPlayerTransform(Transform playerTransform)
     {
         this._player = playerTransform;
+    }
+    void TryFindPlayerCandle()
+    {
+        if (playerCandleLight != null) return;
+
+        // 1. Player 태그 달린 오브젝트 찾기 (Addressables 로드된 플레이어)
+        GameObject player = GameObject.FindGameObjectWithTag(playerTag);
+        if (player == null)
+        {
+            Debug.Log("Letter에서 Player 태그 오브젝트 못 찾음");
+            return;
+        }
+        // 2. 모든 자식 트랜스폼을 돌면서 이름이 playerCandleLightName 인 걸 찾기
+        //    (비활성화 포함)
+        Transform[] children = player.GetComponentsInChildren<Transform>(true);
+        foreach (var t in children)
+        {
+            if (t.name == playerCandleLightName)
+            {
+                playerCandleLight = t.gameObject;
+                Debug.Log("Letter: 플레이어 양초 불빛 찾음 -> " + t.name);
+                break;
+            }
+        }
+
+        if (playerCandleLight == null)
+        {
+            Debug.LogWarning($"Letter: 플레이어 자식에서 '{playerCandleLightName}' 이름을 찾지 못함");
+        }
     }
 }

--- a/Assets/Scripts/Player/FlashlightPickup.cs
+++ b/Assets/Scripts/Player/FlashlightPickup.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public class FlashlightPickup : MonoBehaviour
+{
+    [Header("상호작용 키")]
+    public KeyCode interactKey = KeyCode.E;
+
+    bool pickedUp = false;
+
+    void OnTriggerStay(Collider other)
+    {
+        if (pickedUp) return;
+        if (!other.CompareTag("Player")) return;
+
+        // 여기서 E 키 눌렀을 때만 줍기
+        if (Input.GetKeyDown(interactKey))
+        {
+            var inv = other.GetComponent<PlayerLightInventory>();
+            if (inv != null)
+            {
+                inv.SetModeFlashlight();   // 양초 불 끄고 손전등 모드로 전환
+            }
+
+            pickedUp = true;
+            Destroy(gameObject);           // 바닥에 있는 손전등 아이템 제거
+        }
+    }
+}

--- a/Assets/Scripts/Player/FlashlightPickup.cs.meta
+++ b/Assets/Scripts/Player/FlashlightPickup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3e3544a6a0ff2441a3a69b7db95f594

--- a/Assets/Scripts/Player/PlayerLight.cs
+++ b/Assets/Scripts/Player/PlayerLight.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Runtime.CompilerServices;
+using UnityEngine;
 
 public class FlashlightToggle : MonoBehaviour
 {
@@ -9,8 +10,10 @@ public class FlashlightToggle : MonoBehaviour
     public AudioClip lightOnClip;
     public AudioClip lightOffClip;
 
+    private PlayerLightInventory inv;
     void Awake()
     {
+        inv = GetComponent<PlayerLightInventory>();
         // 자식까지 전부 뒤져서 Light 하나 찾아옴
         flashlightLight = GetComponentInChildren<Light>(true);
 
@@ -20,6 +23,8 @@ public class FlashlightToggle : MonoBehaviour
 
     void Update()
     {
+        if (!inv.hasFlashlight) return;
+
         if (Input.GetKeyDown(KeyCode.F))
         {
             isOn = !isOn;

--- a/Assets/Scripts/Player/PlayerLightInventory.cs
+++ b/Assets/Scripts/Player/PlayerLightInventory.cs
@@ -1,0 +1,39 @@
+﻿using UnityEngine;
+
+public class PlayerLightInventory : MonoBehaviour
+{
+    [Header("플레이어 조명 오브젝트")]
+    public GameObject candleLight;     // FlashHolder 밑 CandleLight
+    public GameObject flashlightObject; // FlashHolder 밑 Flashlight
+
+    [Header("손전등 획득 여부")]
+    public bool hasFlashlight = false;
+
+    void Start()
+    {
+        // 게임 시작: 양초불빛 켜기, 손전등 끄기
+        SetModeCandle();
+    }
+
+    public void SetModeCandle()
+    {
+        hasFlashlight = false;
+
+        if (candleLight != null)
+            candleLight.SetActive(false);
+
+        if (flashlightObject != null)
+            flashlightObject.SetActive(false);
+    }
+
+    public void SetModeFlashlight()
+    {
+        hasFlashlight = true;
+
+        if (candleLight != null)
+            candleLight.SetActive(false);
+
+        if (flashlightObject != null)
+            flashlightObject.SetActive(true);
+    }
+}

--- a/Assets/Scripts/Player/PlayerLightInventory.cs.meta
+++ b/Assets/Scripts/Player/PlayerLightInventory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 68ebbe38f3fff8540a9d1797a89fb99f

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -1,3 +1,5 @@
+using NUnit.Framework.Constraints;
+using System.Collections;
 using UnityEngine;
 
 public class PlayerMovement : MonoBehaviour
@@ -8,7 +10,7 @@ public class PlayerMovement : MonoBehaviour
     private CharacterController controller;
     private Animator animator;
 
-    private bool canMove = true;
+    private bool canMove = false;
 
     private PlayerStamina stamina;      //플레이어 스태미나
 
@@ -25,8 +27,14 @@ public class PlayerMovement : MonoBehaviour
         controller = GetComponent<CharacterController>();
         animator = GetComponent<Animator>();
         stamina = GetComponent<PlayerStamina>();
+        // 3초 후 플레이어 움직임 적용 시킴 -> 맵 생성 중에 맵 바깥으로 떨어지지 않도록.
+        StartCoroutine(EnableMoveDelay()); 
     }
-
+    IEnumerator EnableMoveDelay()
+    {
+        yield return new WaitForSeconds(3f);
+        canMove = true;
+    }
     // Update is called once per frame
     void Update()
     {


### PR DESCRIPTION
1. 시작 방에서 편지를 읽을 때 책상위의 양초를 얻는 것처럼 구현.
2. 미스테리 방의 화장대 위의 손전등 아이템 앞에서 E키를 눌러 손전등 아이템 획득 가능하도록 구현.
3. 맵 생성 중 플레이어 캐릭터가 맵 바깥으로 떨어지는 문제 수정.