### PR TITLE
손전등 레이 수정

### DIFF
--- a/Assets/Animator/Main Animator Controller.controller
+++ b/Assets/Animator/Main Animator Controller.controller
@@ -66,6 +66,31 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 0
+--- !u!1101 &-3738775442974674007
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Stun
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 2760292067941380112}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-2715331135540167507
 AnimatorState:
   serializedVersion: 6
@@ -139,6 +164,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: Stun
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -164,6 +195,28 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1101 &2018994372893418328
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4120205286891567758}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.91071427
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &2549067728087057462
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -189,6 +242,33 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &2760292067941380112
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: StunAnim
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 2018994372893418328}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 325648a93b80ba7419e4e49e872ce28a, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &3598543395590892507
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -252,8 +332,12 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 4120205286891567758}
     m_Position: {x: 320, y: 120, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 2760292067941380112}
+    m_Position: {x: 320, y: 40, z: 0}
   m_ChildStateMachines: []
-  m_AnyStateTransitions: []
+  m_AnyStateTransitions:
+  - {fileID: -3738775442974674007}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []

--- a/Assets/Prefabs/Monster/MainMon.prefab
+++ b/Assets/Prefabs/Monster/MainMon.prefab
@@ -573,7 +573,7 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
-  canStun: 0
+  canStun: 1
   stunDuration: 3
   stunCooltime: 5
   stunTriggerName: Stun

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -1305,12 +1305,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::FlashStun
   flashlightLight: {fileID: 8461090811885979761}
+  rayOrigin: {fileID: 3278609418077876340}
+  rayLocalDirection: {x: 0, y: 0, z: 1}
   stunRange: 15
+  stunRadius: 1.5
   checkInterval: 0.1
   enemyLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  alignFlashToRay: 0
+  debugRay: 1
 --- !u!1 &2360184454438569486
 GameObject:
   m_ObjectHideFlags: 0
@@ -7105,6 +7108,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: OVRCameraRigGame
       objectReference: {fileID: 0}
+    - target: {fileID: 4822191257550933517, guid: 5d42ad4c5ed768b46add2b0fa2ce8ba2, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4965891401851847804, guid: 5d42ad4c5ed768b46add2b0fa2ce8ba2, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -7347,7 +7354,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1767310008238479403, guid: 6f5c89de9c90e46858810b535bbcf29b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.027086675
+      value: 0.027086668
       objectReference: {fileID: 0}
     - target: {fileID: 1767310008238479403, guid: 6f5c89de9c90e46858810b535bbcf29b, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/Scripts/Flashlight/FlashStun.cs
+++ b/Assets/Scripts/Flashlight/FlashStun.cs
@@ -2,11 +2,18 @@
 
 public class FlashStun : MonoBehaviour
 {
-    [Header("실제 빛 켜지는 Light 컴포넌트")]
+    [Header("실제 빛이 나가는 손전등 Light")]
     public Light flashlightLight;
 
-    [Header("스턴 레이 범위")]
+    [Header("레이 시작 위치(손전등 머리 부분)")]
+    public Transform rayOrigin;  // 안 넣으면 flashlightLight 위치 사용
+
+    [Header("레이 로컬 방향 (모델 축에 맞게 조정)")]
+    public Vector3 rayLocalDirection = Vector3.forward; // 예: (0,1,0) 이면 로컬 Y+ 방향
+
+    [Header("스턴 레이 범위 / 굵기")]
     public float stunRange = 15f;
+    public float stunRadius = 0.3f;   // 판정 반경 (값 키우면 더 널널해짐)
 
     [Header("몇 초마다 한 번씩만 스턴 체크 할지")]
     public float checkInterval = 0.1f;
@@ -14,63 +21,103 @@ public class FlashStun : MonoBehaviour
     [Header("맞출 레이어 (Enemy 레이어만 쓰면 좋음)")]
     public LayerMask enemyLayers = ~0;
 
-    [Header("레이 방향에 손전등도 맞출지 여부")]
-    public bool alignFlashToRay = false;   // 원하면 켜기
+    [Header("디버그 레이 표시 여부")]
+    public bool debugRay = true;
 
     private float nextCheckTime = 0f;
-    private Camera cam;
 
-    //손전등 토글 스크립트 참조
+    // 손전등 토글 스크립트 참조 (깜빡임/ON/OFF 상태 확인용)
     private PlayerLight playerLight;
+
     void Awake()
     {
-        cam = Camera.main;   // 메인 카메라 자동 찾기 (Cinemachine이 움직이는 그 카메라)
         playerLight = GetComponentInParent<PlayerLight>();
+
+        // rayOrigin 안 넣어줬으면 기본값으로 세팅
+        if (rayOrigin == null)
+        {
+            if (flashlightLight != null)
+                rayOrigin = flashlightLight.transform;
+            else
+                rayOrigin = transform;
+        }
     }
 
     void Reset()
     {
+        // 에디터에서 컴포넌트 추가할 때 자동으로 Light 찾아주기
         flashlightLight = GetComponentInChildren<Light>();
+
+        if (flashlightLight != null)
+            rayOrigin = flashlightLight.transform;
+        else
+            rayOrigin = transform;
     }
 
     void Update()
     {
+        // 체크 간격
         if (Time.time < nextCheckTime) return;
         nextCheckTime = Time.time + checkInterval;
 
-        if (flashlightLight == null || !flashlightLight.enabled) return;
+        // 손전등 꺼져 있으면 스턴 없음
+        if (flashlightLight == null || !flashlightLight.enabled)
+            return;
 
+        // 깜빡이는 상태(기절 불가 상태)면 패스
         if (playerLight != null && playerLight.IsFlickering)
             return;
 
-        // 혹시 씬 재로드 등으로 날아갔을 때 대비
-        if (cam == null) cam = Camera.main;
-        if (cam == null) return;   // 진짜 카메라 없으면 그냥 종료
+        if (rayOrigin == null)
+            rayOrigin = transform;
 
-        // 1. "화면에서 마우스 포인터 위치" 기준 레이 만들기
-        Vector3 mousePos = Input.mousePosition;
-        Ray ray = cam.ScreenPointToRay(mousePos); // ← 여기서 상하/좌우 다 반영됨
+        // === 1. 레이 시작점 / 방향 ===
+        Vector3 origin = rayOrigin.position;   // 손전등 머리 위치
+        // 로컬 방향벡터(rayLocalDirection)를 월드 방향으로 변환해서 사용
+        Vector3 dir = rayOrigin.TransformDirection(rayLocalDirection.normalized);
 
-        Vector3 origin = ray.origin;
-        Vector3 dir = ray.direction;
-
-        // 손전등도 이 레이 방향을 보게 하고 싶으면
-        if (alignFlashToRay)
+        // 디버그용 레이 (중심선)
+        if (debugRay)
         {
-            transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
+            Debug.DrawRay(origin, dir * stunRange, Color.cyan);
         }
 
-        // 디버그용 레이 (Game/Scene 뷰에서 Gizmos 켜야 보임)
-        Debug.DrawRay(origin, dir * stunRange, Color.cyan);
-
-        // 2. 그 레이가 적을 맞추면 스턴
-        if (Physics.Raycast(origin, dir, out RaycastHit hit, stunRange, enemyLayers))
+        // === 2. 굵은 레이(SphereCast)로 몬스터 스턴 판정 ===
+        if (Physics.SphereCast(origin, stunRadius, dir,
+                               out RaycastHit hit,
+                               stunRange, enemyLayers))
         {
+            // 맞은 콜라이더에서 EnemyAI 찾기 (부모까지 포함)
             EnemyAI enemy = hit.collider.GetComponentInParent<EnemyAI>();
             if (enemy != null)
             {
                 enemy.StunByFlashlight();
             }
         }
+    }
+
+    // 씬뷰에서 선택했을 때 레이 두께까지 보이게 하는 기즈모
+    void OnDrawGizmosSelected()
+    {
+        if (!debugRay) return;
+        if (rayOrigin == null)
+        {
+            if (flashlightLight != null)
+                rayOrigin = flashlightLight.transform;
+            else
+                rayOrigin = transform;
+        }
+
+        Gizmos.color = Color.cyan;
+
+        Vector3 origin = rayOrigin.position;
+        Vector3 dir = rayOrigin.TransformDirection(rayLocalDirection.normalized);
+
+        // 중심선
+        Gizmos.DrawLine(origin, origin + dir * stunRange);
+
+        // 시작점과 끝점에 반지름 표시
+        Gizmos.DrawWireSphere(origin, stunRadius);
+        Gizmos.DrawWireSphere(origin + dir * stunRange, stunRadius);
     }
 }


### PR DESCRIPTION
1. 손전등 레이가 손전등에서 정면 방향으로 나가도록 수정

2. 손전등 레이를 두껍게 하여 스턴 판정이 좋아지도록 수정 -> 인스펙터에서 Radius 값 수정을 통하여 판정 정도를 변경 가능.

4. 메인 몬스터가 스턴 가능하도록 변경

5. 메인 몬스터 스턴 애니메이션 설정 -> 미들 몬스터 스턴 애니메이션 재사용