### PR TITLE
메인 몬스터 발소리 겹침 문제 수정

### DIFF
--- a/Assets/Animation/MainMonRunUpper.anim
+++ b/Assets/Animation/MainMonRunUpper.anim
@@ -55856,32 +55856,4 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events:
-  - time: 0
-    functionName: PlayRunFootstep
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
-  - time: 0.26666668
-    functionName: PlayRunFootstep
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
-  - time: 0.56666666
-    functionName: PlayRunFootstep
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
-  - time: 0.8333333
-    functionName: PlayRunFootstep
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
+  m_Events: []

--- a/Assets/Scripts/Monster/DeadGameover.cs
+++ b/Assets/Scripts/Monster/DeadGameover.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using Unity.Cinemachine;
 using UnityEngine;
@@ -26,7 +26,11 @@ public class DeadGameover : MonoBehaviour, IDeadMon
 
     [Header("Global Volume")]
     [SerializeField]private GameObject glitchVolume;
-    
+
+    //타임 라인 재생 중이면 발소리가 안나도록
+    //FootstepSound 스크립트에서 사용할 수 있도록 static 플래그 변수 선언
+    public static bool IsGameoverTimelinePlaying = false;
+
     void Start()
     {
         if (timeline != null)
@@ -35,6 +39,9 @@ public class DeadGameover : MonoBehaviour, IDeadMon
 
     private void OnTimelineFinished(PlayableDirector obj)
     {
+        // 타임 라인 끝남
+        DeadGameover.IsGameoverTimelinePlaying = false;
+
         // StartCoroutine(CallReSpawn());
         // ✅ GameManager에게 리스폰 실행을 위임합니다.
         if (GameManager.instance != null)
@@ -65,9 +72,13 @@ public class DeadGameover : MonoBehaviour, IDeadMon
         if (other.CompareTag("Player"))
         {
             hasPlayed = false;
+
+            //타임 라인 시작
+            DeadGameover.IsGameoverTimelinePlaying = true;
+
             gameObject.GetComponent<CapsuleCollider>().enabled = false; // Collider 비활성화 추가 실행 방지
             gameObject.GetComponent<NavMeshAgent>().isStopped = true; //몬스터들 이동 멈추기 
-    
+            
             Debug.Log(gameObject.name);
             if(playerObject != null)
              playerObject.SetActive(false); // 플레이어 잠시 비활성화

--- a/Assets/Scripts/Monster/EnemyAI.cs
+++ b/Assets/Scripts/Monster/EnemyAI.cs
@@ -270,7 +270,7 @@ public class EnemyAI : Monster
     // 손전등에서 호출할 함수
     public void StunByFlashlight()
     {
-        if (!canStun) return;   // 메인 몬스터는 그냥 무시
+        if (!canStun) return;   // 인스펙터 CanStun 옵션에 따라 스턴 여부 판정
 
         if (Time.time < nextStunTime) return;   //쿨타임 지나야 스턴 되도록 설정
         if (isStunned) return;  // 이미 기절 중이면 또 안 걸림

--- a/Assets/Scripts/Monster/FootstepSound.cs
+++ b/Assets/Scripts/Monster/FootstepSound.cs
@@ -36,6 +36,9 @@ public class FootstepSound : MonoBehaviour
     //걷을 때 소리를 재생할 함수
     public void PlayFootstep()
     {
+        // 메인 몬스터 타임라인 재생 중일 때 발소리가 안나도록
+        if (DeadGameover.IsGameoverTimelinePlaying) return;
+
         //태그를 비교해 재생할 발소리 오디오 클립을 playingFootstepClips에 저장
         if (this.CompareTag("MainMon"))
         {
@@ -62,6 +65,9 @@ public class FootstepSound : MonoBehaviour
     // --- 달리기 ---
     public void PlayRunFootstep()
     {
+        // 메인 몬스터 타임라인 재생 중일 때 발소리가 안나도록
+        if (DeadGameover.IsGameoverTimelinePlaying) return;
+
         if (CompareTag("MainMon"))
             playingFootstepClips = MainMonRunFootstepClips;
         else if (CompareTag("MiddleMon"))


### PR DESCRIPTION
1. 상체 애니메이션 발소리 재생 이벤트 제거를 통해 메인 몬스터의 발소리 겹칩 문제 해결

2. DeadGameover 스크립트에 플래그 변수를 추가하여 메인몬스터의 타임라인 재생 시 FootstepSound 스크립트에서 발소리가 재생되지 않도록 하는 로직 추가.

3. EnemyAI 스크립트 주석 수정.